### PR TITLE
Add option to provide full url for graphql

### DIFF
--- a/internal-log-fetcher/src/log_entry.rs
+++ b/internal-log-fetcher/src/log_entry.rs
@@ -1,6 +1,5 @@
 use crate::{
-    graphql::internal_logs_query::InternalLogsQueryInternalLogs,
-    utils::convert_timestamp_to_float,
+    graphql::internal_logs_query::InternalLogsQueryInternalLogs, utils::convert_timestamp_to_float,
 };
 use serde::ser::{Serialize, SerializeSeq, Serializer};
 use serde_json::Map;

--- a/internal-log-fetcher/src/main.rs
+++ b/internal-log-fetcher/src/main.rs
@@ -6,17 +6,15 @@ use structopt::StructOpt;
 
 mod authentication;
 mod graphql;
-mod mina_server;
 mod log_entry;
+mod mina_server;
 mod utils;
 
 #[derive(Debug, StructOpt)]
 #[structopt(about = "Internal logging fetcher.")]
 struct Opts {
-    #[structopt(name = "NODE_ADDRESS")]
-    address: String,
-    #[structopt(short = "p", long)]
-    graphql_port: u16,
+    #[structopt(subcommand)]
+    target: Target,
     #[structopt(short = "k", long, parse(from_os_str))]
     secret_key_path: PathBuf,
     #[structopt(short = "o", long, parse(from_os_str))]
@@ -25,13 +23,28 @@ struct Opts {
     https: bool,
 }
 
+#[derive(Debug, StructOpt)]
+enum Target {
+    #[structopt(about = "Specify Node address and port separately")]
+    NodeAddressPort {
+        #[structopt(name = "NODE_ADDRESS")]
+        address: String,
+        #[structopt(short = "p", long)]
+        graphql_port: u16,
+    },
+    #[structopt(about = "Specify full URL")]
+    FullUrl {
+        #[structopt(name = "URL")]
+        url: String,
+    },
+}
+
 fn main() {
     let opts = Opts::from_args();
     let secret_key_base64 = std::fs::read_to_string(opts.secret_key_path).unwrap();
     let config = mina_server::MinaServerConfig {
         secret_key_base64,
-        address: opts.address,
-        graphql_port: opts.graphql_port,
+        target: opts.target,
         output_dir_path: opts.output_dir_path,
         use_https: opts.https,
     };


### PR DESCRIPTION
I added a little modification to the args, so we can connect to the exposed service on our cluster. 