### PR TITLE
Disable write batching for PSQL

### DIFF
--- a/internal-log-fetcher/Cargo.lock
+++ b/internal-log-fetcher/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,6 +63,186 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+dependencies = [
+ "async-lock",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener 5.3.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333c456b97c3f2d50604e8b2624253b7f787208cb72eb75e64b0ad11b221652c"
+dependencies = [
+ "async-std",
+]
+
+[[package]]
+name = "async-process"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451e3cf68011bd56771c79db04a9e333095ab6349f7e47592b788e9b98720cc8"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.3.1",
+ "futures-lite",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c634475f29802fde2b8f0b505b1bd00dfe4df7d4a000f0b36f7671197d5c3615"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +252,12 @@ dependencies = [
  "quote",
  "syn 2.0.37",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atty"
@@ -103,6 +298,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +334,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,9 +360,12 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -177,7 +394,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -209,6 +426,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +458,12 @@ checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crypto-common"
@@ -282,6 +514,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,24 +569,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.3"
+name = "equivalent"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
+name = "event-listener"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
 dependencies = [
- "cc",
- "libc",
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+dependencies = [
+ "event-listener 5.3.1",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -375,9 +640,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -431,6 +696,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
+name = "futures-lite"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +730,12 @@ name = "futures-task"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -508,6 +792,18 @@ name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "graphql-introspection-query"
@@ -578,8 +874,27 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
- "indexmap",
+ "http 0.2.9",
+ "indexmap 1.9.3",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap 2.7.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -593,15 +908,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "headers"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
- "base64",
+ "base64 0.21.4",
  "bytes",
- "headers-core",
- "http",
+ "headers-core 0.2.0",
+ "http 0.2.9",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
+dependencies = [
+ "base64 0.21.4",
+ "bytes",
+ "headers-core 0.3.0",
+ "http 1.1.0",
  "httpdate",
  "mime",
  "sha1",
@@ -613,7 +949,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http",
+ "http 0.2.9",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -642,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "http"
@@ -658,13 +1003,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.9",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -679,6 +1058,42 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "httpmock"
+version = "0.8.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d649264818ad8f19c01f72b4ddf2f0cfcd1183691b956de733673e81d8a51f"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-std",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-timer",
+ "futures-util",
+ "headers 0.4.0",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.5.1",
+ "hyper-util",
+ "lazy_static",
+ "log",
+ "path-tree",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "stringmetrics",
+ "tabwriter",
+ "thiserror",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "humantime"
@@ -696,9 +1111,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.21",
+ "http 0.2.9",
+ "http-body 0.4.5",
  "httparse",
  "httpdate",
  "itoa",
@@ -711,14 +1126,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.7",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.9",
+ "hyper 0.14.27",
  "rustls",
  "tokio",
  "tokio-rustls",
@@ -731,10 +1167,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.27",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.5.1",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -761,13 +1212,142 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.4.0"
+name = "icu_collections"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -777,7 +1357,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -785,11 +1375,12 @@ name = "internal-log-fetcher"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.21.4",
  "chrono",
  "ed25519-dalek",
  "futures-util",
  "graphql_client",
+ "httpmock",
  "object_store",
  "rand 0.7.3",
  "reqwest",
@@ -833,6 +1424,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,15 +1440,21 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.7"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "litemap"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -865,6 +1471,9 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "memchr"
@@ -899,13 +1508,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -917,7 +1526,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 0.2.9",
  "httparse",
  "log",
  "memchr",
@@ -964,16 +1573,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.3",
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,12 +1588,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c776db4f332b571958444982ff641d2531417a326ca368995073b639205d58"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.21.4",
  "bytes",
  "chrono",
  "futures",
  "humantime",
- "hyper",
+ "hyper 0.14.27",
  "itertools",
  "parking_lot",
  "percent-encoding",
@@ -1075,6 +1674,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,14 +1699,23 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "path-tree"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c7fabb0b56aba5d2eb3fa9b1547c187f21f8c051295a7b97a50be6a9332f4cb"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
@@ -1136,10 +1750,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "polling"
+version = "3.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.4.0",
+ "pin-project-lite",
+ "rustix",
+ "tracing",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1280,20 +1920,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "reqwest"
 version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
- "base64",
+ "base64 0.21.4",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.21",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "hyper 0.14.27",
  "hyper-rustls",
  "hyper-tls",
  "ipnet",
@@ -1346,15 +2015,15 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.14"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1375,7 +2044,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64",
+ "base64 0.21.4",
 ]
 
 [[package]]
@@ -1409,7 +2078,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1489,6 +2158,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,6 +2228,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,9 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "snafu"
@@ -1597,12 +2282,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1616,6 +2301,18 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stringmetrics"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b3c8667cd96245cbb600b8dec5680a7319edd719c5aa2b5d23c6bff94f39765"
 
 [[package]]
 name = "strsim"
@@ -1676,6 +2373,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "tabwriter"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a327282c4f64f6dc37e3bba4c2b6842cc3a992f204fa58d917696a89f691e5f6"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1685,7 +2402,7 @@ dependencies = [
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1728,44 +2445,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.6.0"
+name = "tinystr"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
- "tinyvec_macros",
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.4",
+ "socket2 0.5.8",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1909,7 +2620,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 0.2.9",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -1935,25 +2646,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -1984,9 +2680,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.4.1"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2000,10 +2696,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "value-bag"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
 
 [[package]]
 name = "vcpkg"
@@ -2057,9 +2771,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "headers",
- "http",
- "hyper",
+ "headers 0.3.9",
+ "http 0.2.9",
+ "hyper 0.14.27",
  "log",
  "mime",
  "mime_guess",
@@ -2223,7 +2937,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2232,7 +2946,25 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2241,13 +2973,29 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2257,10 +3005,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2269,10 +3029,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2281,10 +3059,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2293,13 +3083,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+ "synstructure",
 ]
 
 [[package]]
@@ -2316,6 +3169,28 @@ name = "zeroize_derive"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/internal-log-fetcher/Cargo.toml
+++ b/internal-log-fetcher/Cargo.toml
@@ -14,9 +14,15 @@ chrono = "0.4"
 ed25519-dalek = "1"
 futures-util = "0.3"
 graphql_client = { version = "0.12" }
-object_store = { version = "0.6", features = ["reqwest", "gcp", "serde", "serde_json", "aws"] }
+object_store = { version = "0.6", features = [
+  "reqwest",
+  "gcp",
+  "serde",
+  "serde_json",
+  "aws",
+] }
 rand = "0.7"
-reqwest = { version = "0.11", features = ["json"]}
+reqwest = { version = "0.11", features = ["json"] }
 serde = "1.0"
 serde_json = { version = "1", features = ["raw_value"] }
 structopt = "0.3"
@@ -24,3 +30,6 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 warp = "0.3"
+
+[dev-dependencies]
+httpmock = "0.8.0-alpha.1"

--- a/internal-log-fetcher/Cargo.toml
+++ b/internal-log-fetcher/Cargo.toml
@@ -14,7 +14,7 @@ chrono = "0.4"
 ed25519-dalek = "1"
 futures-util = "0.3"
 graphql_client = { version = "0.12" }
-object_store = { version = "0.6", features = ["reqwest", "gcp", "serde", "serde_json"] }
+object_store = { version = "0.6", features = ["reqwest", "gcp", "serde", "serde_json", "aws"] }
 rand = "0.7"
 reqwest = { version = "0.11", features = ["json"]}
 serde = "1.0"

--- a/internal-log-fetcher/src/discovery.rs
+++ b/internal-log-fetcher/src/discovery.rs
@@ -1,14 +1,14 @@
 // Copyright (c) Viable Systems
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
-use anyhow::{Result};
+use anyhow::Result;
 use chrono::{DateTime, Utc};
 use futures_util::StreamExt;
 use object_store::aws::{AmazonS3, AmazonS3Builder};
 use object_store::{path::Path, ObjectStore};
 use serde::Deserialize;
 use std::collections::HashSet;
+use std::env;
 use tracing::{info, warn};
 
 use crate::node::NodeIdentity;
@@ -16,20 +16,18 @@ use crate::node::NodeIdentity;
 #[derive(Debug, Deserialize)]
 struct MetaToBeSaved {
     remote_addr: String,
-    peer_id: String,
     submitter: String,
     graphql_control_port: u16,
 }
 
-pub struct DiscoveryParams {
-    pub offset_min: u64,
-    pub limit: usize,
-    pub only_block_producers: bool,
+struct AwsConfig {
+    s3: AmazonS3,
+    prefix: String,
 }
 
 pub struct DiscoveryService {
-    gcs: AmazonS3,
-    prefix: String,
+    online_url: Option<String>,
+    aws: Option<AwsConfig>,
 }
 
 fn offset_by_time(prefix_str: String, t: DateTime<Utc>) -> String {
@@ -38,79 +36,117 @@ fn offset_by_time(prefix_str: String, t: DateTime<Utc>) -> String {
     format!("{}/{}/{}", prefix_str, d_str, t_str)
 }
 
-impl DiscoveryService {
-    pub fn try_new() -> Result<Self> {
-        let prefix = env::var("AWS_PREFIX")?;
-        let bucket = env::var("AWS_BUCKET")?;
-        let gcs = AmazonS3Builder::from_env().with_bucket_name(bucket).build()?;
-        Ok(Self { gcs, prefix })
+fn new_from_aws() -> Result<DiscoveryService> {
+    let prefix = env::var("AWS_PREFIX")?;
+    let bucket = env::var("AWS_BUCKET")?;
+    let s3 = AmazonS3Builder::from_env()
+        .with_bucket_name(bucket)
+        .build()?;
+    let aws = AwsConfig {
+        s3: s3,
+        prefix: prefix,
+    };
+    Ok(DiscoveryService {
+        aws: Some(aws),
+        online_url: None,
+    })
+}
+
+async fn fetch_online(url: &str) -> Result<HashSet<NodeIdentity>> {
+    // Use reqwest to make an async GET request.
+    let response = reqwest::get(url).await?;
+
+    // Deserialize the JSON response into Vec<Meta>.
+    let meta_array = response.json::<Vec<MetaToBeSaved>>().await?;
+
+    let mut results = HashSet::new();
+    for meta in meta_array {
+        results.insert(NodeIdentity {
+            ip: meta.remote_addr.to_string(),
+            graphql_port: meta.graphql_control_port,
+            submitter_pk: Some(meta.submitter),
+        });
     }
 
-    pub async fn discover_participants(
-        &mut self,
-        params: DiscoveryParams,
-    ) -> Result<HashSet<NodeIdentity>> {
-        // We add 30 extra seconds of grace period because sometimes some nodes don't
-        // make it in time.
-        let before = Utc::now()
-            - chrono::Duration::minutes(params.offset_min as i64)
-            - chrono::Duration::seconds(30);
-        let prefix_str = format!("{}/submissions", self.prefix);
-        let prefix_str2 = prefix_str.clone();
-        let offset: Path = offset_by_time(prefix_str, before).try_into()?;
-        let prefix: Path = prefix_str2.into();
-        info!("Obtaining list of objects in bucket...");
-        let it = self.gcs.list_with_offset(Some(&prefix), &offset).await?;
-        let mut results = HashSet::new();
-        let list_results: Vec<_> = it.collect().await;
-        info!("Results count {}", list_results.len());
+    Ok(results)
+}
 
-        let list_results: Vec<_> = list_results
-            .into_iter()
-            .filter_map(|result| match result {
-                Err(err) => {
-                    warn!("Got error when fetching listing objects: {:?}", err);
-                    None
-                }
-                Ok(result) => Some(result),
-            })
-            .rev()
-            .collect();
+async fn discover_aws(aws: &AwsConfig) -> Result<HashSet<NodeIdentity>> {
+    let before = Utc::now() - chrono::Duration::minutes(20);
+    let prefix_str = format!("{}/submissions", aws.prefix);
+    let prefix_str2 = prefix_str.clone();
+    let offset: Path = offset_by_time(prefix_str, before).try_into()?;
+    let prefix: Path = prefix_str2.into();
+    info!("Obtaining list of objects in bucket...");
+    let it = aws.s3.list_with_offset(Some(&prefix), &offset).await?;
+    let mut results = HashSet::new();
+    let list_results: Vec<_> = it.collect().await;
+    info!("Results count {}", list_results.len());
 
-        let futures = list_results.into_iter().map(|object_meta| async move {
-            let bucket = env::var("AWS_BUCKET")?;
-            let gcs = AmazonS3Builder::from_env().with_bucket_name(bucket).build()?;
-            let bytes = gcs
-                .get_range(&object_meta.location, 0..1_000_000_000)
-                .await?;
-            let meta: MetaToBeSaved = serde_json::from_slice(&bytes)?;
-            Ok((object_meta.location, meta))
-        });
-
-        let gcs_results: Vec<anyhow::Result<(Path, MetaToBeSaved)>> =
-            futures_util::future::join_all(futures).await;
-        let gcs_results = gcs_results.into_iter().filter_map(|result| match result {
+    let list_results: Vec<_> = list_results
+        .into_iter()
+        .filter_map(|result| match result {
             Err(err) => {
-                warn!("Failure when fetching object: {:?}", err);
+                warn!("Got error when fetching listing objects: {:?}", err);
                 None
             }
             Ok(result) => Some(result),
-        });
+        })
+        .rev()
+        .collect();
 
-        for (location, meta) in gcs_results {
-            let colon_ix = meta.remote_addr.find(':').unwrap_or_else(|| {
-                meta.remote_addr.len()
-            });
-            results.insert(NodeIdentity {
-                ip: meta.remote_addr[..colon_ix].to_string(),
-                graphql_port: meta.graphql_control_port,
-                submitter_pk: Some(meta.submitter),
-            });
-            if params.limit > 0 && results.len() >= params.limit {
-                break;
-            }
+    let futures = list_results.into_iter().map(|object_meta| async move {
+        let bytes = aws
+            .s3
+            .get_range(&object_meta.location, 0..1_000_000_000)
+            .await?;
+        let meta: MetaToBeSaved = serde_json::from_slice(&bytes)?;
+        Ok((object_meta.location, meta))
+    });
+
+    let aws_results: Vec<anyhow::Result<(Path, MetaToBeSaved)>> =
+        futures_util::future::join_all(futures).await;
+    let aws_results = aws_results.into_iter().filter_map(|result| match result {
+        Err(err) => {
+            warn!("Failure when fetching object: {:?}", err);
+            None
         }
+        Ok(result) => Some(result),
+    });
 
-        Ok(results)
+    for (_, meta) in aws_results {
+        let colon_ix = meta
+            .remote_addr
+            .find(':')
+            .unwrap_or_else(|| meta.remote_addr.len());
+        results.insert(NodeIdentity {
+            ip: meta.remote_addr[..colon_ix].to_string(),
+            graphql_port: meta.graphql_control_port,
+            submitter_pk: Some(meta.submitter),
+        });
+    }
+
+    Ok(results)
+}
+
+impl DiscoveryService {
+    pub fn try_new() -> Result<Self> {
+        match env::var("ONLINE_URL") {
+            Ok(url) if !url.is_empty() => Ok(DiscoveryService {
+                online_url: Some(url),
+                aws: None,
+            }),
+            _ => new_from_aws(),
+        }
+    }
+
+    pub async fn discover_participants(&self) -> Result<HashSet<NodeIdentity>> {
+        match &self.aws {
+            Some(aws) => discover_aws(&aws).await,
+            None => match &self.online_url {
+                Some(url) => fetch_online(&url).await,
+                None => panic!("neither aws nor online url configured"),
+            },
+        }
     }
 }

--- a/internal-log-fetcher/src/discovery.rs
+++ b/internal-log-fetcher/src/discovery.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::env;
-use anyhow::{anyhow, Result};
+use anyhow::{Result};
 use chrono::{DateTime, Utc};
 use futures_util::StreamExt;
 use object_store::aws::{AmazonS3, AmazonS3Builder};
@@ -98,13 +98,9 @@ impl DiscoveryService {
         });
 
         for (location, meta) in gcs_results {
-            let colon_ix = meta.remote_addr.find(':').ok_or_else(|| {
-                anyhow!(
-                    "wrong remote address in submission {}: {}",
-                    location,
-                    meta.remote_addr
-                )
-            })?;
+            let colon_ix = meta.remote_addr.find(':').unwrap_or_else(|| {
+                meta.remote_addr.len()
+            });
             results.insert(NodeIdentity {
                 ip: meta.remote_addr[..colon_ix].to_string(),
                 graphql_port: meta.graphql_control_port,

--- a/internal-log-fetcher/src/discovery.rs
+++ b/internal-log-fetcher/src/discovery.rs
@@ -59,8 +59,8 @@ fn node_identity(
         let index = (control_port / 10000) as usize - 1;
         if let Some(overrides) = url_overrides {
             if let Some(url_template) = overrides.get(index) {
-                let port_suffix = control_port % 10000;
-                let ip = url_template.replace("{}", &port_suffix.to_string());
+                let template_value = control_port % 10000;
+                let ip = url_template.replace("{}", &template_value.to_string());
                 return NodeIdentity {
                     ip,
                     graphql_port: 80,

--- a/internal-log-fetcher/src/discovery.rs
+++ b/internal-log-fetcher/src/discovery.rs
@@ -1,10 +1,11 @@
 // Copyright (c) Viable Systems
 // SPDX-License-Identifier: Apache-2.0
 
+use std::env;
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Utc};
 use futures_util::StreamExt;
-use object_store::gcp::{GoogleCloudStorage, GoogleCloudStorageBuilder};
+use object_store::aws::{AmazonS3, AmazonS3Builder};
 use object_store::{path::Path, ObjectStore};
 use serde::Deserialize;
 use std::collections::HashSet;
@@ -27,19 +28,22 @@ pub struct DiscoveryParams {
 }
 
 pub struct DiscoveryService {
-    gcs: GoogleCloudStorage,
+    gcs: AmazonS3,
+    prefix: String,
 }
 
-fn offset_by_time(t: DateTime<Utc>) -> String {
+fn offset_by_time(prefix_str: String, t: DateTime<Utc>) -> String {
     let t_str = t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
     let d_str = t.format("%Y-%m-%d");
-    format!("submissions/{}/{}", d_str, t_str)
+    format!("{}/{}/{}", prefix_str, d_str, t_str)
 }
 
 impl DiscoveryService {
     pub fn try_new() -> Result<Self> {
-        let gcs = GoogleCloudStorageBuilder::from_env().build()?;
-        Ok(Self { gcs })
+        let prefix = env::var("AWS_PREFIX")?;
+        let bucket = env::var("AWS_BUCKET")?;
+        let gcs = AmazonS3Builder::from_env().with_bucket_name(bucket).build()?;
+        Ok(Self { gcs, prefix })
     }
 
     pub async fn discover_participants(
@@ -51,8 +55,10 @@ impl DiscoveryService {
         let before = Utc::now()
             - chrono::Duration::minutes(params.offset_min as i64)
             - chrono::Duration::seconds(30);
-        let offset: Path = offset_by_time(before).try_into()?;
-        let prefix: Path = "submissions".into();
+        let prefix_str = format!("{}/submissions", self.prefix);
+        let prefix_str2 = prefix_str.clone();
+        let offset: Path = offset_by_time(prefix_str, before).try_into()?;
+        let prefix: Path = prefix_str2.into();
         info!("Obtaining list of objects in bucket...");
         let it = self.gcs.list_with_offset(Some(&prefix), &offset).await?;
         let mut results = HashSet::new();
@@ -72,7 +78,8 @@ impl DiscoveryService {
             .collect();
 
         let futures = list_results.into_iter().map(|object_meta| async move {
-            let gcs = GoogleCloudStorageBuilder::from_env().build()?;
+            let bucket = env::var("AWS_BUCKET")?;
+            let gcs = AmazonS3Builder::from_env().with_bucket_name(bucket).build()?;
             let bytes = gcs
                 .get_range(&object_meta.location, 0..1_000_000_000)
                 .await?;

--- a/internal-log-fetcher/src/discovery.rs
+++ b/internal-log-fetcher/src/discovery.rs
@@ -126,7 +126,10 @@ pub async fn fetch_online(
     Ok(results)
 }
 
-async fn discover_aws(aws: &AwsConfig) -> Result<HashSet<NodeIdentity>> {
+async fn discover_aws(
+    aws: &AwsConfig,
+    host_overrides: Option<&[String]>,
+) -> Result<HashSet<NodeIdentity>> {
     let before = Utc::now() - chrono::Duration::minutes(20);
     let prefix_str = format!("{}/submissions", aws.prefix);
     let prefix_str2 = prefix_str.clone();
@@ -174,7 +177,7 @@ async fn discover_aws(aws: &AwsConfig) -> Result<HashSet<NodeIdentity>> {
             &meta.remote_addr,
             meta.graphql_control_port,
             meta.submitter.clone(),
-            None,
+            host_overrides,
         );
         results.insert(node);
     }
@@ -198,7 +201,7 @@ impl DiscoveryService {
         host_overrides: Option<Vec<String>>,
     ) -> Result<HashSet<NodeIdentity>> {
         match &self.aws {
-            Some(aws) => discover_aws(aws).await,
+            Some(aws) => discover_aws(aws, host_overrides.as_deref()).await,
             None => match &self.online_url {
                 Some(url) => fetch_online(url, host_overrides.as_deref()).await,
                 None => panic!("neither aws nor online url configured"),

--- a/internal-log-fetcher/src/main.rs
+++ b/internal-log-fetcher/src/main.rs
@@ -74,7 +74,6 @@ pub struct Manager {
     node_discovery: NodeDiscoveryMode,
     secret_key_base64: String,
     consumer_executable_path: String,
-    offset_min: u64,
     node_names: HashMap<String, String>,
 }
 
@@ -117,7 +116,6 @@ impl Manager {
             node_discovery,
             secret_key_base64,
             consumer_executable_path,
-            offset_min: 15,
             node_names,
         })
     }
@@ -127,13 +125,7 @@ impl Manager {
             NodeDiscoveryMode::Fixed(id) => Ok(HashSet::from_iter(vec![id.clone()].into_iter())),
             NodeDiscoveryMode::Discovery(discovery) => {
                 info!("Performing discovery...");
-                let participants = discovery
-                    .discover_participants(discovery::DiscoveryParams {
-                        offset_min: self.offset_min,
-                        limit: 10_000,
-                        only_block_producers: false,
-                    })
-                    .await?;
+                let participants = discovery.discover_participants().await?;
 
                 info!("Participants: {:?}", participants);
                 Ok(participants)

--- a/internal-log-fetcher/src/main.rs
+++ b/internal-log-fetcher/src/main.rs
@@ -428,7 +428,6 @@ mod tests {
     async fn test_fetch_online() -> Result<(), Box<dyn std::error::Error>> {
         // Start a lightweight mock server
         let server = MockServer::start();
-
         // Define the mock response data
         let mock_data = r#"
         [
@@ -459,7 +458,6 @@ mod tests {
             }
         ]
         "#;
-
         // Create a mock on the server
         let _mock = server.mock(|when, then| {
             when.method(GET).path("/v1/online");
@@ -467,17 +465,14 @@ mod tests {
                 .header("content-type", "application/json")
                 .body(mock_data);
         });
-
         // Define URL overrides
         let host_overrides = Some(vec![
             "plain-{}.hetzner-itn.gcp.o1test.net".to_string(),
             "another-{}.example.com".to_string(),
         ]);
-
         // Call the fetch_online function with the mock server URL
         let online_nodes =
             fetch_online(&server.url("/v1/online"), host_overrides.as_deref()).await?;
-
         // Define the expected set of NodeIdentity instances
         let expected_nodes: HashSet<NodeIdentity> = vec![
             NodeIdentity {
@@ -518,10 +513,8 @@ mod tests {
         ]
         .into_iter()
         .collect();
-
         // Assert that the fetched nodes match the expected nodes
         assert_eq!(online_nodes, expected_nodes);
-
         Ok(())
     }
 }

--- a/internal-log-fetcher/src/main.rs
+++ b/internal-log-fetcher/src/main.rs
@@ -41,7 +41,7 @@ struct Opts {
     db_uri: Option<String>,
     #[structopt(
         long,
-        about = "A list of template strings specifying host components to override within URLs provided by the Uptime backend service."
+        about = "A list of template strings specifying host components that will override the 'remote_addr' properties provided by the Uptime backend service."
     )]
     host_overrides: Option<Vec<String>>,
 }

--- a/internal-log-fetcher/src/mina_server.rs
+++ b/internal-log-fetcher/src/mina_server.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Viable Systems
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
 use crate::{
     authentication::{Authenticator, BasicAuthenticator, SequentialAuthenticator},
     graphql,
@@ -11,6 +10,7 @@ use crate::{
 use anyhow::{anyhow, Result};
 use base64::{engine::general_purpose, Engine};
 use graphql_client::GraphQLQuery;
+use std::env;
 use std::{
     fs::File,
     io::Write,
@@ -246,7 +246,10 @@ impl MinaServer {
                     }
                 }
             }
-            let fetch_interval_ms = env::var("FETCH_INTERVAL_MS").ok().and_then(|s| s.parse::<u64>().ok()).unwrap_or_else(|| 10000);
+            let fetch_interval_ms = env::var("FETCH_INTERVAL_MS")
+                .ok()
+                .and_then(|s| s.parse::<u64>().ok())
+                .unwrap_or_else(|| 10000);
 
             tokio::time::sleep(std::time::Duration::from_millis(fetch_interval_ms)).await;
         }

--- a/internal-log-fetcher/src/mina_server.rs
+++ b/internal-log-fetcher/src/mina_server.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Viable Systems
 // SPDX-License-Identifier: Apache-2.0
 
+use std::env;
 use crate::{
     authentication::{Authenticator, BasicAuthenticator, SequentialAuthenticator},
     graphql,
@@ -245,8 +246,9 @@ impl MinaServer {
                     }
                 }
             }
+            let fetch_interval_ms = env::var("FETCH_INTERVAL_MS").ok().and_then(|s| s.parse::<u64>().ok()).unwrap_or_else(|| 10000);
 
-            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+            tokio::time::sleep(std::time::Duration::from_millis(fetch_interval_ms)).await;
         }
     }
 

--- a/internal-log-fetcher/src/mina_server.rs
+++ b/internal-log-fetcher/src/mina_server.rs
@@ -249,7 +249,7 @@ impl MinaServer {
             let fetch_interval_ms = env::var("FETCH_INTERVAL_MS")
                 .ok()
                 .and_then(|s| s.parse::<u64>().ok())
-                .unwrap_or_else(|| 10000);
+                .unwrap_or(10000);
 
             tokio::time::sleep(std::time::Duration::from_millis(fetch_interval_ms)).await;
         }

--- a/internal-log-fetcher/src/trace_consumer.rs
+++ b/internal-log-fetcher/src/trace_consumer.rs
@@ -44,14 +44,12 @@ impl TraceConsumer {
 
         let stdout_log_file = OpenOptions::new()
             .create(true)
-            
             .append(true)
             .open(base_path.join("consumer-stdout.log"))
             .unwrap();
 
         let stderr_log_file = OpenOptions::new()
             .create(true)
-            
             .append(true)
             .open(base_path.join("consumer-stderr.log"))
             .unwrap();

--- a/internal-log-fetcher/src/trace_consumer.rs
+++ b/internal-log-fetcher/src/trace_consumer.rs
@@ -44,14 +44,14 @@ impl TraceConsumer {
 
         let stdout_log_file = OpenOptions::new()
             .create(true)
-            .write(true)
+            
             .append(true)
             .open(base_path.join("consumer-stdout.log"))
             .unwrap();
 
         let stderr_log_file = OpenOptions::new()
             .create(true)
-            .write(true)
+            
             .append(true)
             .open(base_path.join("consumer-stderr.log"))
             .unwrap();

--- a/internal-log-fetcher/src/trace_consumer.rs
+++ b/internal-log-fetcher/src/trace_consumer.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Viable Systems
 // SPDX-License-Identifier: Apache-2.0
 
+use std::env;
 use std::{fs::OpenOptions, path::PathBuf};
-
 use tokio::process::Command;
 
 pub mod internal_trace_file {
@@ -41,6 +41,8 @@ impl TraceConsumer {
 
     pub async fn run(&mut self) -> tokio::io::Result<tokio::process::Child> {
         let base_path = self.main_trace_file_path.parent().unwrap().to_path_buf();
+        let handle_status_change =
+            env::var("HANDLE_STATUS_CHANGE").unwrap_or_else(|_| "false".to_string());
 
         let stdout_log_file = OpenOptions::new()
             .create(true)
@@ -63,6 +65,8 @@ impl TraceConsumer {
             .arg(&self.db_uri)
             .arg("--port")
             .arg(format!("{}", self.graphql_port))
+            .arg("--handle-status-change")
+            .arg(&handle_status_change)
             .stdout(stdout_log_file)
             .stderr(stderr_log_file)
             .kill_on_drop(true)

--- a/src/block_trace.ml
+++ b/src/block_trace.ml
@@ -44,7 +44,8 @@ let block_source_from_string = function
   | "Unknown" ->
       `Unknown
   | _other ->
-      `Unknown (* TODO: print warning*)
+      `Unknown
+(* TODO: print warning*)
 
 let status_to_yojson = Util.flatten_yojson_variant status_to_yojson
 
@@ -59,7 +60,8 @@ let status_from_string = function
   | "Success" ->
       `Success
   | _ ->
-      `Pending (* TODO: warning *)
+      `Pending
+(* TODO: warning *)
 
 type t =
   { source : block_source

--- a/src/connection_context.ml
+++ b/src/connection_context.ml
@@ -4,13 +4,9 @@ open Async
 module Db = struct
   type pool_t =
     ((module Caqti_async.CONNECTION), Caqti_error.t) Caqti_async.Pool.t
+
   let set, get =
-    let dbpool :
-        ([`Postgres | `Sqlite] * pool_t)
-        option
-        ref =
-      ref None
-    in
+    let dbpool : ([ `Postgres | `Sqlite ] * pool_t) option ref = ref None in
     let set_db engine pool = dbpool := Some (engine, pool) in
     let get_db () =
       Option.value_exn ~message:"Database not initialized" !dbpool
@@ -24,8 +20,7 @@ let with_connection f =
   let engine, pool = Db.get () in
   let with_connection_context f (conn : (module Caqti_async.CONNECTION)) =
     Async_kernel.Async_kernel_scheduler.with_local key (Some conn) ~f:(fun () ->
-      f engine
-    )
+        f engine )
   in
   Caqti_async.Pool.use (with_connection_context f) pool
 

--- a/src/graphql_internal.ml
+++ b/src/graphql_internal.ml
@@ -84,12 +84,13 @@ module Params = struct
     if body = "" then empty
     else
       let json = Yojson.Basic.from_string body in
-      { query = Yojson.Basic.Util.(json |> member "query" |> to_option to_string)
+      { query =
+          Yojson.Basic.Util.(json |> member "query" |> to_option to_string)
       ; variables =
           Yojson.Basic.Util.(json |> member "variables" |> to_option to_assoc)
       ; operation_name =
           Yojson.Basic.Util.(
-            json |> member "operationName" |> to_option to_string )
+            json |> member "operationName" |> to_option to_string)
       }
 
   let of_graphql_body body =

--- a/src/graphql_server.ml
+++ b/src/graphql_server.ml
@@ -222,7 +222,7 @@ let create_graphql_server ~bind_to_address ~schema ~server_description port =
                 respond_with_cors "Route not found" `Not_found >>| lift )
         | `Other _ ->
             respond_with_cors "HTTP method not supported" `Method_not_allowed
-            >>| lift ) )
+            >>| lift ))
   |> Deferred.map ~f:(fun _ ->
          Log.Global.info "Created %s at: http://localhost:%i/graphql"
            server_description port )

--- a/src/internal_trace_consumer.ml
+++ b/src/internal_trace_consumer.ml
@@ -359,9 +359,13 @@ module Main_handler = struct
     Ivar.fill_if_empty main_trace_synced () ;
     return ()
 
-  let start_file_processing_iteration () = Connection_context.start ()
+  let start_file_processing_iteration = function
+    | `Sqlite -> Connection_context.start ()
+    | `Postgres -> Deferred.unit
 
-  let complete_file_processing_iteration () = Connection_context.commit ()
+  let complete_file_processing_iteration = function
+    | `Sqlite -> Connection_context.commit ()
+    | `Postgres -> Deferred.unit
 end
 
 module Prover_handler = struct
@@ -386,9 +390,9 @@ module Prover_handler = struct
 
   let eof_reached () = Deferred.unit (* Nothing to do *)
 
-  let start_file_processing_iteration () = Deferred.unit
+  let start_file_processing_iteration _ = Deferred.unit
 
-  let complete_file_processing_iteration () = Deferred.unit
+  let complete_file_processing_iteration _ = Deferred.unit
 end
 
 module Verifier_handler = struct
@@ -413,9 +417,9 @@ module Verifier_handler = struct
 
   let eof_reached () = Deferred.unit (* Nothing to do *)
 
-  let start_file_processing_iteration () = Deferred.unit
+  let start_file_processing_iteration _ = Deferred.unit
 
-  let complete_file_processing_iteration () = Deferred.unit
+  let complete_file_processing_iteration _ = Deferred.unit
 end
 
 module Main_trace_processor = Trace_file_processor.Make (Main_handler)
@@ -495,7 +499,7 @@ let serve =
      fun () ->
        let db_uri, engine = compute_engine_and_uri ~db_path ~db_uri in
        let%bind pool = open_database_or_fail db_uri in
-       Connection_context.Db.set pool ;
+       Connection_context.Db.set engine pool ;
        let%bind result = Store.initialize_database engine in
        let%bind () = abort_on_error result in
        let insecure_rest_server = true in
@@ -562,7 +566,7 @@ let process =
      fun () ->
        let db_uri, engine = compute_engine_and_uri ~db_path ~db_uri in
        let%bind pool = open_database_or_fail db_uri in
-       Connection_context.Db.set pool ;
+       Connection_context.Db.set engine pool ;
        let%bind result = Store.initialize_database engine in
        let%bind () = abort_on_error result in
        Log.Global.info "Consuming main trace events from file: %s"

--- a/src/internal_trace_consumer.ml
+++ b/src/internal_trace_consumer.ml
@@ -360,12 +360,16 @@ module Main_handler = struct
     return ()
 
   let start_file_processing_iteration = function
-    | `Sqlite -> Connection_context.start ()
-    | `Postgres -> Deferred.unit
+    | `Sqlite ->
+        Connection_context.start ()
+    | `Postgres ->
+        Deferred.unit
 
   let complete_file_processing_iteration = function
-    | `Sqlite -> Connection_context.commit ()
-    | `Postgres -> Deferred.unit
+    | `Sqlite ->
+        Connection_context.commit ()
+    | `Postgres ->
+        Deferred.unit
 end
 
 module Prover_handler = struct
@@ -508,7 +512,7 @@ let serve =
          Graphql_server.create_graphql_server
            ~bind_to_address:
              Tcp.Bind_to_address.(
-               if insecure_rest_server then All_addresses else Localhost )
+               if insecure_rest_server then All_addresses else Localhost)
            ~schema:Graphql_server.schema ~server_description:"GraphQL server"
            port
        in

--- a/src/store.ml
+++ b/src/store.ml
@@ -467,6 +467,7 @@ module Q = struct
           started_at float NOT NULL,
           metadata_json %s,
           call_id int NOT NULL,
+          gossip bool not null default false,
 
           FOREIGN KEY (block_trace_id) REFERENCES block_trace(block_trace_id)
         )
@@ -689,7 +690,7 @@ module Q = struct
           source, call_id, is_control, name, started_at,
           CAST(metadata_json AS text) metadata_json
         FROM block_trace_checkpoint
-        WHERE block_trace_id = ? AND main_trace = ?
+        WHERE block_trace_id = ? AND main_trace = ? AND NOT gossip
         ORDER BY block_trace_checkpoint_id ASC
       |eos}
 

--- a/src/store.ml
+++ b/src/store.ml
@@ -686,7 +686,6 @@ module Q = struct
 end
 
 let initialize_database engine (module Db : Caqti_async.CONNECTION) =
-  let open Deferred.Result.Let_syntax in
   Q.initialize_schema engine
   |> Deferred.List.fold ~init:(Ok ()) ~f:(fun acc q ->
          if Result.is_error acc then Deferred.return acc else Db.exec q () )

--- a/src/store.ml
+++ b/src/store.ml
@@ -334,7 +334,7 @@ module Q = struct
     in
     let rep =
       Caqti_type.(
-        tup3 (tup3 float float float) (tup4 string int int string) string )
+        tup3 (tup3 float float float) (tup4 string int int string) string)
     in
     custom ~encode ~decode rep
 
@@ -366,7 +366,7 @@ module Q = struct
     in
     let rep =
       Caqti_type.(
-        tup4 string (tup4 string int int string) (tup2 float float) string )
+        tup4 string (tup4 string int int string) (tup2 float float) string)
     in
     custom ~encode ~decode rep
 
@@ -394,7 +394,8 @@ module Q = struct
         | "P" ->
             `Prover
         | _ ->
-            `Main (* TODO print warning *)
+            `Main
+        (* TODO print warning *)
       in
       (* TODO: print warning on metadata decoding failure or fail row decoding *)
       let checkpoint =
@@ -415,9 +416,9 @@ module Q = struct
     let primary_key_int, json_type =
       match engine with
       | `Sqlite ->
-          "integer PRIMARY KEY AUTOINCREMENT", "text"
+          ("integer PRIMARY KEY AUTOINCREMENT", "text")
       | `Postgres ->
-          "SERIAL PRIMARY KEY", "jsonb"
+          ("SERIAL PRIMARY KEY", "jsonb")
     in
     [ (unit ->. unit)
       @@ sprintf

--- a/src/store.ml
+++ b/src/store.ml
@@ -882,6 +882,6 @@ module Testing = struct
            | Ok pool ->
                pool
          in
-         Connection_context.Db.set pool ;
+         Connection_context.Db.set `Sqlite pool ;
          test_db () >>= report_error )
 end

--- a/src/store.ml
+++ b/src/store.ml
@@ -475,13 +475,9 @@ module Q = struct
            primary_key_int json_type
     ; (unit ->. unit)
         {eos|
-        CREATE INDEX IF NOT EXISTS block_trace_checkpoint_source_idx
-        ON block_trace_checkpoint (source)
-      |eos}
-    ; (unit ->. unit)
-        {eos|
-        CREATE INDEX IF NOT EXISTS block_trace_checkpoint_main_trace_idx
-        ON block_trace_checkpoint (main_trace)
+        CREATE INDEX IF NOT EXISTS block_trace_checkpoint_block_trace_id_main_trace_gossip
+        ON block_trace_checkpoint
+        (block_trace_id, main_trace) WHERE (NOT gossip)
       |eos}
     ; (unit ->. unit)
         {eos|
@@ -570,6 +566,7 @@ module Q = struct
       |eos}
 
   let base_block_traces_query =
+    (* TODO use window function instead of INNER JOIN *)
     sprintf
       {eos|
       SELECT

--- a/src/trace_file_processor.ml
+++ b/src/trace_file_processor.ml
@@ -15,9 +15,11 @@ module Make (Handler : sig
 
   val eof_reached : unit -> unit Deferred.t
 
-  val start_file_processing_iteration : [ `Postgres | `Sqlite ] -> unit Deferred.t
+  val start_file_processing_iteration :
+    [ `Postgres | `Sqlite ] -> unit Deferred.t
 
-  val complete_file_processing_iteration : [ `Postgres | `Sqlite ] -> unit Deferred.t
+  val complete_file_processing_iteration :
+    [ `Postgres | `Sqlite ] -> unit Deferred.t
 end) =
 struct
   let last_rotate_end_timestamp = ref 0.0


### PR DESCRIPTION
Problem: batches of transactions are accumulated before an EOF of trace file is encountered. Given files are written in parallel by the fetcher, this may lead to potentially indefinite accumulation of batches without commitment.

Solution: disable batching for Postgresql (as it was originally introduced as a necessary optimization for sqlite).